### PR TITLE
Minor changes to imports and package start command for integration on…

### DIFF
--- a/django_react_starter/frontend/package.json
+++ b/django_react_starter/frontend/package.json
@@ -12,7 +12,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "react-scripts --openssl-legacy-provider start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/django_react_starter/frontend/src/App.js
+++ b/django_react_starter/frontend/src/App.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import logo from './logo.svg';
 import './App.css';
 


### PR DESCRIPTION
My computer wasn't working with react with the default settings.
Errors were ["error:0308010C:digital envelope routines::unsupported"] which was remedied by putting "react-scripts --openssl-legacy-provider start" in the "start" field under "scripts" in package.json

Also got "React not in scope" error when starting up app which was remedied by adding the first import in App.js
import React from "react"