### PR TITLE
Added sslstart command to differentiate between start

### DIFF
--- a/django_react_starter/frontend/package.json
+++ b/django_react_starter/frontend/package.json
@@ -12,7 +12,8 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts --openssl-legacy-provider start",
+    "start": "react-scripts start",
+    "sslstart": "react-scripts --openssl-legacy-provider start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
Needed different start vs sslstart for integration for development on different computers.
Now there is:
```
"start": "react-scripts start",
"sslstart": "react-scripts --openssl-legacy-provider start",
```
either one may work on your computer